### PR TITLE
Bugfix: emit metrics even if the underlying ASGI app raises exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "timing-asgi"
-version = "0.1.0"
+version = "0.1.1"
 description = "ASGI middleware to emit timing metrics with something like statsd"
 authors = ["Steinn Eldjárn Sigurðarson <steinnes@gmail.com>"]
 license = "MIT"

--- a/timing_asgi/utils.py
+++ b/timing_asgi/utils.py
@@ -14,9 +14,16 @@ class TimingStats(object):
     def __init__(self, name=None):
         self.name = name
 
-    def __enter__(self):
+    def start(self):
         self.start_time = time.time()
         self.start_cpu_time = get_cpu_time()
+
+    def stop(self):
+        self.end_time = time.time()
+        self.end_cpu_time = get_cpu_time()
+
+    def __enter__(self):
+        self.start()
         return self
 
     @property
@@ -28,8 +35,7 @@ class TimingStats(object):
         return self.end_cpu_time - self.start_cpu_time
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.end_time = time.time()
-        self.end_cpu_time = get_cpu_time()
+        self.stop()
 
 
 class PathToName(MetricNamer):


### PR DESCRIPTION
Refactor to catch, then re-raise exceptions so metrics are emitted (with http_status:500).