### PR TITLE
Reduce log noise from unsupported ASGI scopes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,5 +5,6 @@ jobs:
     docker:
       - image: themattrix/tox
     steps:
+      - run: apt-get update && apt-get install -y openssh-client git
       - checkout
       - run: tox

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ test_%:
 lint:
 	poetry run flake8 timing_asgi/ tests/
 
+black:
+	poetry run black $(shell git diff --name-only --diff-filter d HEAD|grep \.py$)
+
 
 clean:
 	rm -rf dist/ pip-wheel-metadata *.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "timing-asgi"
-version = "0.2.0"
+version = "0.2.1"
 description = "ASGI middleware to emit timing metrics with something like statsd"
 authors = ["Steinn Eldjárn Sigurðarson <steinnes@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ requests = "^2.21"
 pytest-asyncio = "^0.10.0"
 asynctest = "^0.12.2"
 flake8 = "^3.7"
+black = {version = "^20.8b1", allow-prereleases = true}
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,34 +8,36 @@ from starlette.applications import Starlette
 from timing_asgi import TimingMiddleware
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def starlette_app():
     yield Starlette()
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def timing_client(starlette_app):
     yield mock.MagicMock()
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def mw(starlette_app, timing_client):
     yield TimingMiddleware(starlette_app, client=timing_client)
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def send():
     yield asynctest.CoroutineMock()
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.yield_fixture(scope="function")
 def receive():
     yield asynctest.CoroutineMock()
 
 
 @pytest.fixture
 def scope():
-    def inner(type=None, method=None, scheme=None, server=None, path=None, headers=None):
+    def inner(
+        type=None, method=None, scheme=None, server=None, path=None, headers=None
+    ):
         if type is None:
             type = "http"
         if method is None:
@@ -49,5 +51,13 @@ def scope():
         if headers is None:
             headers = []
 
-        return {"type": type, "method": method, "scheme": scheme, "server": server, "path": path, "headers": headers}
+        return {
+            "type": type,
+            "method": method,
+            "scheme": scheme,
+            "server": server,
+            "path": path,
+            "headers": headers,
+        }
+
     return inner

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -79,7 +79,7 @@ async def test_timing_middleware_asgi_skips_timingstats_if_scope_type_is_not_htt
         ):
             await mw(scope(type="websocket"), receive, send)
     assert not timing_stats.entered
-    assert mock_alog.info.called
+    assert mock_alog.debug.called
 
 
 @pytest.mark.asyncio

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -25,7 +25,9 @@ def test_timing_middleware_ensure_compliance_no_timing_attr(starlette_app, mw):
         mw.ensure_compliance(broken_client)
 
 
-def test_timing_middleware_ensure_compliance_timing_attr_not_callable(starlette_app, mw):
+def test_timing_middleware_ensure_compliance_timing_attr_not_callable(
+    starlette_app, mw
+):
     class FakeClient:
         timing = "this is not the method you're looking for"
 
@@ -44,47 +46,62 @@ def test_timing_middleware_ensure_compliance(starlette_app, mw):
 
 
 def test_timing_middleware_init_calls_ensure_compliance(starlette_app):
-    with mock.patch('timing_asgi.TimingMiddleware.ensure_compliance') as mock_ensure_compliance:
+    with mock.patch(
+        "timing_asgi.TimingMiddleware.ensure_compliance"
+    ) as mock_ensure_compliance:
         TimingMiddleware(starlette_app, client="foo")
     assert mock_ensure_compliance.called_with("foo")
 
 
 @pytest.mark.asyncio
-async def test_timing_middleware_asgi_skips_timingstats_if_scope_metric_raises_exception(mw, scope, send, receive):
+async def test_timing_middleware_asgi_skips_timingstats_if_scope_metric_raises_exception(
+    mw, scope, send, receive
+):
     mw.metric_namer = mock.MagicMock(side_effect=AttributeError)
     timing_stats = FakeTimingStats()
-    with mock.patch('timing_asgi.middleware.alog') as mock_alog:
-        with mock.patch('timing_asgi.middleware.TimingStats', return_value=timing_stats):
+    with mock.patch("timing_asgi.middleware.alog") as mock_alog:
+        with mock.patch(
+            "timing_asgi.middleware.TimingStats", return_value=timing_stats
+        ):
             await mw(scope(), receive, send)
     assert not timing_stats.entered
     assert mock_alog.error.called
 
 
 @pytest.mark.asyncio
-async def test_timing_middleware_asgi_skips_timingstats_if_scope_type_is_not_http(mw, scope, send, receive):
+async def test_timing_middleware_asgi_skips_timingstats_if_scope_type_is_not_http(
+    mw, scope, send, receive
+):
     timing_stats = FakeTimingStats()
-    with mock.patch('timing_asgi.middleware.alog') as mock_alog:
-        with mock.patch('timing_asgi.middleware.TimingStats', return_value=timing_stats):
-            await mw(scope(type='websocket'), receive, send)
+    with mock.patch("timing_asgi.middleware.alog") as mock_alog:
+        with mock.patch(
+            "timing_asgi.middleware.TimingStats", return_value=timing_stats
+        ):
+            await mw(scope(type="websocket"), receive, send)
     assert not timing_stats.entered
     assert mock_alog.info.called
 
 
 @pytest.mark.asyncio
-async def test_timing_middleware_asgi_sends_timings(mw, scope, timing_client, receive, send):
+async def test_timing_middleware_asgi_sends_timings(
+    mw, scope, timing_client, receive, send
+):
     await mw(scope(), receive, send)
     assert timing_client.timing.called
 
 
 @pytest.mark.asyncio
-async def test_timing_middleware_sends_timings_even_if_app_raises_exception(mw, scope, timing_client, receive, send):
+async def test_timing_middleware_sends_timings_even_if_app_raises_exception(
+    mw, scope, timing_client, receive, send
+):
     def app(scope):
         async def raiser(send, receive):
             raise Exception("hell")
+
         return raiser
 
     mw.app = app
     with pytest.raises(Exception):
         await mw(scope(), receive, send)
     assert timing_client.timing.called
-    assert 'http_status:500' in timing_client.timing.call_args_list[0][1]['tags']
+    assert "http_status:500" in timing_client.timing.call_args_list[0][1]["tags"]

--- a/tests/test_path_to_name.py
+++ b/tests/test_path_to_name.py
@@ -3,4 +3,4 @@ from timing_asgi.utils import PathToName
 
 def test_timing_middleware_scope_metric_route_not_found(scope, timing_client):
     scope_metric = PathToName(prefix="myapp")
-    assert scope_metric(scope(path="/something")) == 'myapp.something'
+    assert scope_metric(scope(path="/something")) == "myapp.something"

--- a/tests/test_starlette_scope_to_name.py
+++ b/tests/test_starlette_scope_to_name.py
@@ -15,9 +15,17 @@ def test_starlette_scope_metric_route_found(starlette_app, scope):
     def something_else():
         return JSONResponse({})
 
-    metric_namer = StarletteScopeToName("myapp", starlette_app, fallback=mock.MagicMock())
-    assert metric_namer(scope(path="/something")) == "myapp.test_starlette_scope_to_name.something"
-    assert metric_namer(scope(path="/something_else")) == "myapp.test_starlette_scope_to_name.something_else"
+    metric_namer = StarletteScopeToName(
+        "myapp", starlette_app, fallback=mock.MagicMock()
+    )
+    assert (
+        metric_namer(scope(path="/something"))
+        == "myapp.test_starlette_scope_to_name.something"
+    )
+    assert (
+        metric_namer(scope(path="/something_else"))
+        == "myapp.test_starlette_scope_to_name.something_else"
+    )
     assert not metric_namer.fallback.called
 
 
@@ -27,8 +35,13 @@ def test_starlette_scope_metric_class_based_endpoint(starlette_app, scope):
         def get(self, request):
             return JSONResponse({})
 
-    metric_namer = StarletteScopeToName("myapp", starlette_app, fallback=mock.MagicMock())
-    assert metric_namer(scope(path="/howclassy")) == "myapp.test_starlette_scope_to_name.HowClassy"
+    metric_namer = StarletteScopeToName(
+        "myapp", starlette_app, fallback=mock.MagicMock()
+    )
+    assert (
+        metric_namer(scope(path="/howclassy"))
+        == "myapp.test_starlette_scope_to_name.HowClassy"
+    )
 
 
 def test_starlette_scope_metric_uses_name_if_found(starlette_app, scope):
@@ -36,12 +49,19 @@ def test_starlette_scope_metric_uses_name_if_found(starlette_app, scope):
     def fancy(request):
         return JSONResponse({})
 
-    metric_namer = StarletteScopeToName("myapp", starlette_app, fallback=mock.MagicMock())
-    assert metric_namer(scope(path="/fancy")) == "myapp.test_starlette_scope_to_name.this.is.fancy"
+    metric_namer = StarletteScopeToName(
+        "myapp", starlette_app, fallback=mock.MagicMock()
+    )
+    assert (
+        metric_namer(scope(path="/fancy"))
+        == "myapp.test_starlette_scope_to_name.this.is.fancy"
+    )
 
 
 def test_starlette_scope_metric_route_not_found(starlette_app, scope):
-    metric_namer = StarletteScopeToName("myapp", starlette_app, fallback=mock.MagicMock())
+    metric_namer = StarletteScopeToName(
+        "myapp", starlette_app, fallback=mock.MagicMock()
+    )
     assert metric_namer(scope(path="/something")) == metric_namer.fallback.return_value
 
 

--- a/timing_asgi/integrations/starlette.py
+++ b/timing_asgi/integrations/starlette.py
@@ -5,7 +5,7 @@ from timing_asgi.utils import PathToName
 
 
 class StarletteScopeToName(MetricNamer):
-    """ Class which extracts a suitable metric name from a matching Starlette route.
+    """Class which extracts a suitable metric name from a matching Starlette route.
 
     Uses the route name if it has one, but otherwise constructs a name based on the
     full module + method/class path.
@@ -13,6 +13,7 @@ class StarletteScopeToName(MetricNamer):
     Falls back to either a provided fallback callable, or uses PathToName, which is the
     TimingMiddleware default.
     """
+
     def __init__(self, prefix, starlette_app, fallback=None):
         self.prefix = prefix
         self.starlette_app = starlette_app

--- a/timing_asgi/interfaces.py
+++ b/timing_asgi/interfaces.py
@@ -11,6 +11,7 @@ class MetricNamer(ABC):
 
 class TimingClient(ABC):
     """ An abstract class detailing the client interface """
+
     @abstractmethod
     def timing(self, metric_name: str, timing: float, tags: List[str]):
         pass  # pragma: no cover

--- a/timing_asgi/middleware.py
+++ b/timing_asgi/middleware.py
@@ -37,7 +37,7 @@ class TimingMiddleware:
             return send(response)
 
         if scope["type"] != "http":
-            alog.info(f"ASGI scope of type {scope['type']} is not supported yet")
+            alog.debug(f"ASGI scope of type {scope['type']} is not supported yet")
             await self.app(scope, receive, send)
             return
 

--- a/timing_asgi/utils.py
+++ b/timing_asgi/utils.py
@@ -43,5 +43,5 @@ class PathToName(MetricNamer):
         self.prefix = prefix
 
     def __call__(self, scope):
-        path = scope.get('path')[1:]
+        path = scope.get("path")[1:]
         return f"{self.prefix}.{path.replace('/', '.')}"

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ skipsdist=True
 isolated_build = true
 envlist =
     py36,
-    py37
+    py37,
+    py38
 
 [testenv]
 whitelist_externals = /usr/bin/make


### PR DESCRIPTION
This is a minor change, primarily to reduce the log noise when using websockets.  I plan to add basic websocket timing support in the near future.