### PR TITLE
Add README and project URLs to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,11 @@ name = "timing-asgi"
 version = "0.3.0"
 description = "ASGI middleware to emit timing metrics with something like statsd"
 authors = ["Steinn Eldjárn Sigurðarson <steinnes@gmail.com>"]
+readme = "README.md"
 license = "MIT"
+
+[project.urls]
+"Source" = "https://github.com/steinnes/timing-asgi"
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
The content of `README.md` is missing from <https://pypi.org/project/timing-asgi/>, and there's no link there to this repo on GitHub. Adding this metadata should allow both to appear there.