### PR TITLE
Replace alog with standard logging module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A more realistic example which emits the timing metrics to Datadog can be found 
 
 
 ```python
+import logging
 import uvicorn
 
 from starlette.applications import Starlette
@@ -58,6 +59,7 @@ app.add_middleware(
 )
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     uvicorn.run(app)
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-alog = "^0.9.13"
 
 [tool.poetry.dev-dependencies]
 starlette = "^0.12.0"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -59,13 +59,13 @@ async def test_timing_middleware_asgi_skips_timingstats_if_scope_metric_raises_e
 ):
     mw.metric_namer = mock.MagicMock(side_effect=AttributeError)
     timing_stats = FakeTimingStats()
-    with mock.patch("timing_asgi.middleware.alog") as mock_alog:
+    with mock.patch("timing_asgi.middleware.log") as mock_log:
         with mock.patch(
             "timing_asgi.middleware.TimingStats", return_value=timing_stats
         ):
             await mw(scope(), receive, send)
     assert not timing_stats.entered
-    assert mock_alog.error.called
+    assert mock_log.error.called
 
 
 @pytest.mark.asyncio
@@ -73,13 +73,13 @@ async def test_timing_middleware_asgi_skips_timingstats_if_scope_type_is_not_htt
     mw, scope, send, receive
 ):
     timing_stats = FakeTimingStats()
-    with mock.patch("timing_asgi.middleware.alog") as mock_alog:
+    with mock.patch("timing_asgi.middleware.log") as mock_log:
         with mock.patch(
             "timing_asgi.middleware.TimingStats", return_value=timing_stats
         ):
             await mw(scope(type="websocket"), receive, send)
     assert not timing_stats.entered
-    assert mock_alog.debug.called
+    assert mock_log.debug.called
 
 
 @pytest.mark.asyncio

--- a/timing_asgi/middleware.py
+++ b/timing_asgi/middleware.py
@@ -1,6 +1,8 @@
-import alog
+import logging
 
 from .utils import PathToName, TimingStats
+
+log = logging.getLogger(__name__)
 
 
 class TimingMiddleware:
@@ -37,17 +39,17 @@ class TimingMiddleware:
             return send(response)
 
         if scope["type"] != "http":
-            alog.debug(f"ASGI scope of type {scope['type']} is not supported yet")
+            log.debug(f"ASGI scope of type {scope['type']} is not supported yet")
             await self.app(scope, receive, send)
             return
 
         try:
             metric_name = self.metric_namer(scope)
         except AttributeError as e:
-            alog.error(
+            log.error(
                 f"Unable to extract metric name from asgi scope: {scope}, skipping statsd timing"
             )
-            alog.error(f" -> exception: {e}")
+            log.error(f" -> exception: {e}")
             await self.app(scope, receive, send)
             return
 


### PR DESCRIPTION
Fixes issue: [https://github.com/steinnes/timing-asgi/issues/25](https://github.com/steinnes/timing-asgi/issues/25)

`alog` seems to be a package that is not being maintained (inactive for more than 2 years).
Besides it does not play nice with the standard python `logging` module.
As a result, the log messages do not follow the logging configuration used by the users of this package.